### PR TITLE
Fix crash on impl trait

### DIFF
--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -558,6 +558,7 @@ enum RepType {
     PrimArray(String),
     HashCodeArray(String),
     HashCodeStruct(String),
+    Skip,
 }
 
 // Given a Rust type kind, return its RepType. Also note whether the type
@@ -594,6 +595,10 @@ fn get_rep_type(kind: &TyKind, is_ref: &mut bool) -> RepType {
                 return vec_generics_to_rust_type(&path);
             }
             return RepType::HashCodeStruct(String::from(ty_string));
+        }
+        TyKind::ImplTrait(_, _) => {
+            // A bunch of types we want to skip for Daikon.
+            RepType::Skip
         }
         _ => todo!(),
     }
@@ -849,6 +854,9 @@ impl<'a> ArrayContents<'a> {
                         sub_contents: None,
                     }
                 }
+                RepType::Skip => {
+                    continue;
+                }
             };
             match &mut self.sub_contents {
                 None => panic!("No sub_contents in build_contents"),
@@ -1094,6 +1102,9 @@ impl<'a> TopLevlDecl<'a> {
                         }
                     }
                     tmp
+                }
+                RepType::Skip => {
+                    continue;
                 }
             };
             match &self.contents {
@@ -1511,6 +1522,7 @@ impl<'a> DaikonDeclsVisitor<'a> {
                                     }
                                     tmp
                                 }
+                                RepType::Skip => panic!("What TopLevlDecl should we produce here"),
                             };
                             return_decl.write();
                             //write(&mut Box::new(return_decl), "", true, false, "", &mut None);
@@ -1757,6 +1769,9 @@ fn fn_sig_to_toplevl_decls<'a>(
                     }
                 }
                 tmp
+            }
+            RepType::Skip => {
+                continue;
             }
         };
         var_decls.push(Box::new(toplevl_decl));

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -69,7 +69,7 @@ struct DaikonDtraceVisitor<'a> {
 }
 
 // Represents a Rust type.
-// If it is a reference, note this with is_ref in get_basic_type.
+// If it is a reference, note this with is_ref in get_rust_type.
 // For Vec/array, is_ref indicates whether the contents of the
 // container are references or not rather than the container
 // itself. It does not matter if the container is_ref or not,
@@ -97,6 +97,7 @@ enum RustType {
     UserDefVec(String),
     PrimArray(String),
     UserDefArray(String),
+    Skip,  // Types we want to skip.
     NoRet, // For void-returning functions.
     Error, // Used to indicate a type is not primitive.
 }
@@ -178,7 +179,7 @@ fn vec_generics_to_rust_type(generic_args: &Path, is_ref: &mut bool) -> RustType
         Some(args) => match &**args {
             GenericArgs::AngleBracketed(brack_args) => match &brack_args.args[0] {
                 AngleBracketedArg::Arg(arg) => match &arg {
-                    GenericArg::Type(arg_type) => match &get_basic_type(&arg_type.kind, is_ref) {
+                    GenericArg::Type(arg_type) => match &get_rust_type(&arg_type.kind, is_ref) {
                         RustType::Prim(p_type) => RustType::PrimVec(String::from(p_type)),
                         RustType::UserDef(basic_type) => {
                             RustType::UserDefVec(String::from(basic_type))
@@ -218,14 +219,14 @@ pub fn set_output_prefix(input_name: String) {
 // Create a RustType for the given Rust type.
 // * `kind` - Represents the actual type of a parameter in the Rust language.
 // * `is_ref` - Used to determine reference qualifiers on the type.
-fn get_basic_type(kind: &TyKind, is_ref: &mut bool) -> RustType {
+fn get_rust_type(kind: &TyKind, is_ref: &mut bool) -> RustType {
     match &kind {
-        TyKind::Array(arr_type, _anon_const) => match &get_basic_type(&arr_type.kind, is_ref) {
+        TyKind::Array(arr_type, _anon_const) => match &get_rust_type(&arr_type.kind, is_ref) {
             RustType::Prim(p_type) => RustType::PrimArray(String::from(p_type)),
             RustType::UserDef(basic_type) => RustType::UserDefArray(String::from(basic_type)),
             _ => panic!("higher-dim arrays not supported"),
         },
-        TyKind::Slice(arr_type) => match &get_basic_type(&arr_type.kind, is_ref) {
+        TyKind::Slice(arr_type) => match &get_rust_type(&arr_type.kind, is_ref) {
             RustType::Prim(p_type) => RustType::PrimArray(String::from(p_type)),
             RustType::UserDef(basic_type) => RustType::UserDefArray(String::from(basic_type)),
             _ => panic!("higher-dim arrays not supported"),
@@ -235,7 +236,7 @@ fn get_basic_type(kind: &TyKind, is_ref: &mut bool) -> RustType {
         TyKind::Ref(_, mut_ty) => {
             *is_ref = true;
             // recurse to get to the underlying type
-            get_basic_type(&mut_ty.ty.kind, is_ref)
+            get_rust_type(&mut_ty.ty.kind, is_ref)
         }
         TyKind::Path(_, path) => {
             if path.segments.is_empty() {
@@ -251,6 +252,10 @@ fn get_basic_type(kind: &TyKind, is_ref: &mut bool) -> RustType {
             }
             // Return full type: RustType<args>, need generics in some cases.
             RustType::UserDef(ty_string.to_string())
+        }
+        TyKind::ImplTrait(_, _) => {
+            // A bunch of types we want to ignore for Daikon.
+            RustType::Skip
         }
         _ => RustType::Error,
     }
@@ -546,7 +551,7 @@ impl<'a> DaikonDtraceVisitor<'a> {
         let mut ret_is_ref = false;
         let r_ty = match &ret_ty {
             FnRetTy::Default(_span) => RustType::NoRet,
-            FnRetTy::Ty(ty) => get_basic_type(&ty.kind, &mut ret_is_ref),
+            FnRetTy::Ty(ty) => get_rust_type(&ty.kind, &mut ret_is_ref),
         };
         let pr_ty = match &ret_ty {
             FnRetTy::Ty(ty) => ty,
@@ -739,6 +744,7 @@ impl<'a> DaikonDtraceVisitor<'a> {
                 );
                 *i = self.insert_into_block(*i, &userdef_vec_record_ret, body);
             }
+            RustType::Skip => {}
             RustType::NoRet => {}
             RustType::Error => panic!("ret_ty is RustType::Error"),
         }
@@ -1105,7 +1111,7 @@ impl<'a> DaikonDtraceVisitor<'a> {
             };
 
             let mut is_ref = false;
-            let dtrace_print_xfield = match &get_basic_type(&fields[i].ty.kind, &mut is_ref) {
+            let dtrace_print_xfield = match &get_rust_type(&fields[i].ty.kind, &mut is_ref) {
                 RustType::Prim(p_type) => {
                     // We have a vec of ourselves, and the field is
                     if p_type == "String" || p_type == "str" {
@@ -1414,7 +1420,7 @@ impl<'a> DaikonDtraceVisitor<'a> {
             };
 
             let mut is_ref = false;
-            let dtrace_field_vec_rec = match &get_basic_type(&fields[i].ty.kind, &mut is_ref) {
+            let dtrace_field_vec_rec = match &get_rust_type(&fields[i].ty.kind, &mut is_ref) {
                 // don't need p_type because we just call dtrace_print_xfield which handles the type.
                 RustType::Prim(_) => {
                     let first_tmp: &str = &daikon_tmp_counter.to_string();
@@ -1591,6 +1597,9 @@ impl<'a> DaikonDtraceVisitor<'a> {
                         )
                     )
                 }
+                RustType::Skip => {
+                    continue;
+                }
                 RustType::NoRet => String::from(""),
                 RustType::Error => panic!("Field type not handled"),
             };
@@ -1619,7 +1628,7 @@ impl<'a> DaikonDtraceVisitor<'a> {
             };
 
             let mut is_ref = false;
-            let mut dtrace_field_rec = match &get_basic_type(&fields[i].ty.kind, &mut is_ref) {
+            let mut dtrace_field_rec = match &get_rust_type(&fields[i].ty.kind, &mut is_ref) {
                 RustType::Prim(p_type) => {
                     if p_type == "String" || p_type == "str" {
                         substitute(
@@ -1664,6 +1673,9 @@ impl<'a> DaikonDtraceVisitor<'a> {
                     FxHashMap::from_iter([("${field_name}", field_name.as_str())]),
                     DTRACE_CALL_PRINT_FIELD,
                 ),
+                RustType::Skip => {
+                    continue;
+                }
                 RustType::NoRet => String::from(""),
                 RustType::Error => panic!("Field type not handled"),
             };
@@ -1701,7 +1713,7 @@ impl<'a> DaikonDtraceVisitor<'a> {
                     DTRACE_USERDEF,
                 )
             } else {
-                match &get_basic_type(&decl.inputs[i].ty.kind, &mut is_ref) {
+                match &get_rust_type(&decl.inputs[i].ty.kind, &mut is_ref) {
                     RustType::Prim(p_type) => {
                         if p_type == "String" || p_type == "str" {
                             substitute(
@@ -1979,6 +1991,9 @@ impl<'a> DaikonDtraceVisitor<'a> {
                             )
                         );
                         res
+                    }
+                    RustType::Skip => {
+                        continue;
                     }
                     RustType::NoRet => String::from(""),
                     RustType::Error => panic!("Formal arg type not handled."),

--- a/daikon_tests/test/impl-trait-expected.dtrace
+++ b/daikon_tests/test/impl-trait-expected.dtrace
@@ -1,0 +1,8 @@
+main:::ENTER
+this_invocation_nonce
+0
+
+main:::EXIT1
+this_invocation_nonce
+0
+

--- a/daikon_tests/test/impl-trait-expected.pp
+++ b/daikon_tests/test/impl-trait-expected.pp
@@ -1,0 +1,27 @@
+trait Trait {}
+
+fn foo(arg: impl Trait) {
+    let mut __daikon_nonce = 0;
+    let mut __unwrap_nonce = NONCE_COUNTER.lock().unwrap();
+    __daikon_nonce = *__unwrap_nonce;
+    *__unwrap_nonce += 1;
+    drop(__unwrap_nonce);
+    dtrace_entry("foo:::ENTER", __daikon_nonce);
+    dtrace_newline();
+    dtrace_exit("foo:::EXIT1", __daikon_nonce);
+    dtrace_newline();
+    return;
+}
+
+fn main() {
+    let mut __daikon_nonce = 0;
+    let mut __unwrap_nonce = NONCE_COUNTER.lock().unwrap();
+    __daikon_nonce = *__unwrap_nonce;
+    *__unwrap_nonce += 1;
+    drop(__unwrap_nonce);
+    dtrace_entry("main:::ENTER", __daikon_nonce);
+    dtrace_newline();
+    dtrace_exit("main:::EXIT1", __daikon_nonce);
+    dtrace_newline();
+    return;
+}

--- a/daikon_tests/test/impl-trait.rs
+++ b/daikon_tests/test/impl-trait.rs
@@ -1,0 +1,6 @@
+trait Trait {}
+
+// argument position: anonymous type parameter
+fn foo(arg: impl Trait) {}
+
+fn main() {}


### PR DESCRIPTION
Start skipping certain types for decls and dtrace generation. Fixes #26.