### PR TITLE
Fix crash on generic functions

### DIFF
--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1777,6 +1777,10 @@ impl<'a> Visitor<'a> for DaikonDeclsVisitor<'a> {
     ) {
         match &fk {
             FnKind::Fn(_, _, f) => {
+                if !f.generics.params.is_empty() {
+                    // Skip generics for now.
+                    return;
+                }
                 if !f.ident.as_str().starts_with("dtrace") {
                     let ppt_name = f.ident.as_str();
                     write_entry(ppt_name);

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -2125,6 +2125,10 @@ impl<'a> MutVisitor for DaikonDtraceVisitor<'a> {
         // instrumentation.
         match &mut fk {
             FnKind::Fn(_, _, f) => {
+                if !f.generics.params.is_empty() {
+                    // Skip generics for now.
+                    return;
+                }
                 let ppt_name = f.ident.as_str();
                 if ppt_name == "execute" {
                     return;

--- a/daikon_tests/test/generics-expected.dtrace
+++ b/daikon_tests/test/generics-expected.dtrace
@@ -1,0 +1,8 @@
+main:::ENTER
+this_invocation_nonce
+0
+
+main:::EXIT1
+this_invocation_nonce
+0
+

--- a/daikon_tests/test/generics-expected.pp
+++ b/daikon_tests/test/generics-expected.pp
@@ -1,0 +1,14 @@
+fn foo<T>(x: T) {}
+
+fn main() {
+    let mut __daikon_nonce = 0;
+    let mut __unwrap_nonce = NONCE_COUNTER.lock().unwrap();
+    __daikon_nonce = *__unwrap_nonce;
+    *__unwrap_nonce += 1;
+    drop(__unwrap_nonce);
+    dtrace_entry("main:::ENTER", __daikon_nonce);
+    dtrace_newline();
+    dtrace_exit("main:::EXIT1", __daikon_nonce);
+    dtrace_newline();
+    return;
+}

--- a/daikon_tests/test/generics.rs
+++ b/daikon_tests/test/generics.rs
@@ -1,0 +1,3 @@
+fn foo<T>(x: T) {}
+
+fn main() {}


### PR DESCRIPTION
Fixes #5. We still probably crash similarly on generic structs.